### PR TITLE
Run yfinance in thread

### DIFF
--- a/backend/app/market.py
+++ b/backend/app/market.py
@@ -1,6 +1,7 @@
 import aiohttp
 import aioredis
 import yfinance as yf
+import asyncio
 from .config import settings
 
 ALPHAVANTAGE_URL = "https://www.alphavantage.co/query"
@@ -22,7 +23,10 @@ async def fetch_alpha_vantage(symbol: str):
 
 async def fetch_yfinance(symbol: str):
     ticker = yf.Ticker(symbol)
-    data = ticker.history(period="1d")
+    try:
+        data = await asyncio.to_thread(ticker.history, period="1d")
+    except Exception:
+        return None
     if not data.empty:
         return {
             "price": data["Close"].iloc[-1]


### PR DESCRIPTION
## Summary
- prevent blocking event loop when calling yfinance
- handle history errors gracefully

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686970fcda4483309fb4253a4a02c8cd